### PR TITLE
Update rebind and rebindAll to return target

### DIFF
--- a/src/rebindAll.js
+++ b/src/rebindAll.js
@@ -23,4 +23,5 @@ export default (target, source, ...transforms) => {
             target[result] = createReboundMethod(target, source, name);
         }
     }
+    return target;
 };

--- a/test/rebindAllSpec.js
+++ b/test/rebindAllSpec.js
@@ -81,4 +81,8 @@ describe('rebindAll', function() {
         expect(target.xInnerTickSize()).toEqual(source.innerTickSize());
         expect(target.xOuterTickSize()).toEqual(source.outerTickSize());
     });
+
+    it('should return the target', function() {
+        expect(rebindAll(target, source)).toBe(target);
+    });
 });

--- a/test/rebindSpec.js
+++ b/test/rebindSpec.js
@@ -19,7 +19,9 @@ describe('rebind', function() {
     });
 
     it('should have the same behaviour as d3.rebind', function() {
-        rebind(target, source, 'fn');
+        var targetObject = rebind(target, source, 'fn');
+        expect(targetObject).toBe(target);
+
         expect(target.fn())
             .toEqual(value);
 


### PR DESCRIPTION
The README states that `rebind` and `rebindAll` should return the `target`.